### PR TITLE
Saved searches

### DIFF
--- a/cuckoo-search.el
+++ b/cuckoo-search.el
@@ -112,14 +112,14 @@
   (setq header-line-format (elfeed-search--header))))     
 
 (defun cuckoo-search-add-search ()
-  "Adds a new search combo to the list of searchs."
+  "Adds a new search combo to the list of searches."
   (interactive)
-  (let* ((cuckoo-search-list-searces (cuckoo-search-get-list-of-searchs))
+  (let* ((cuckoo-search-list-searces (cuckoo-search-get-list-of-searches))
 	 (elfeed-search-string (read-from-minibuffer "Enter the Elfeed-search-string to use (e.g. @6-months-ago +unread): "))
 	 (cuckoo-search-string (read-from-minibuffer "Enter the cuckoo-search-string to use (e.g. -w China): "))
 	 (search-name (read-from-minibuffer "Please provide a name for the new stream: "))
 	 (search-name (replace-regexp-in-string "[\"'?:;\\\/]" "_" search-name)))
-    (when (not cuckoo-search-list-searchs)
+    (when (not cuckoo-search-list-searches)
       (setq cuckoo-search-list-searches (make-hash-table :test 'equal)))
     (puthash search-name (concat elfeed-search-string "::" cuckoo-search-string) cuckoo-search-list-searces)
     (with-temp-buffer
@@ -128,7 +128,7 @@
 	(write-file cuckoo-saved-searches-config-file)))))
 
 (defun cuckoo-search-get-list-of-searches ()
- "Return cuckoo-search-name-search, a hashtable that includes a list of names and locations of all searchs."
+ "Return cuckoo-search-name-search, a hashtable that includes a list of names and locations of all searches."
  (let ((cuckoo-search-file-exists (cuckoo-search-check-for-search-file)))
    (when cuckoo-search-file-exists
      (let ((cuckoo-search-list-searches (make-hash-table :test 'equal)))
@@ -167,11 +167,11 @@ cuckoo-search-list-searches))))
 	(elfeed-search-update--force))
 	(cuckoo-search-elfeed-restore-header))
       (when (not (string= cuckoo-string ""))
-	(cuckoo-search cuckoo-string)))))
+	(cuckoo-search cuckoo-string))))
 
 (defun cuckoo-search-get-elfeed-string (string)
   "Return the elfeed-search-string."
- (let* ((cuckoo-search-list-searches (cuckoo-search-get-list-of-searchs))
+ (let* ((cuckoo-search-list-searches (cuckoo-search-get-list-of-searches))
        (elfeed-string (gethash string cuckoo-search-list-searches)))
    (string-match "\\(.*?\\)::\\(.*\\)" elfeed-string)
    (setq elfeed-string (match-string 1 elfeed-string))
@@ -179,7 +179,7 @@ cuckoo-search-list-searches))))
 
 (defun cuckoo-search-get-cuckoo-string (string)
    "Return the cuckoo-search-string."
-  (let* ((cuckoo-search-list-searches (cuckoo-search-get-list-of-searchs)) 
+  (let* ((cuckoo-search-list-searches (cuckoo-search-get-list-of-searches)) 
 	 (cuckoo-string (gethash string cuckoo-search-list-searches)))
    (string-match "\\(.*?\\)::\\(.*\\)" cuckoo-string)
    (setq cuckoo-string (match-string 2 cuckoo-string))

--- a/cuckoo-search.el
+++ b/cuckoo-search.el
@@ -153,7 +153,7 @@ cuckoo-search-list-searches))))
 	   (setq cuckoo-search-file-exists t))))
   cuckoo-search-file-exists))
 
-(defun cuckoo-saved-searches ()
+(defun cuckoo-search-saved-searches ()
   "Start a search from the list."
   (interactive)
   (let* ((cuckoo-search-list-searches (cuckoo-search-get-list-of-searches))

--- a/readme.org
+++ b/readme.org
@@ -36,6 +36,10 @@ When visiting the *elfeed-search* buffer invoke "C" (see above) or M-x cuckoo-se
 
 Alternative you could also use "-w Taiwan|China|Ukraine" to search for either Taiwan, China or Ukraine as words.
 
+*** cuckoo-search-saved-searches
+
+The functions =cuckoo-search-add-search=, =cuckoo-search-remove-search= and =cuckoo-search-saved-searches= allow for the management of search routines for later/repeated use. Both, Elfeed and cuckoo-search strings can be stored (leave the cuckoo-search-string empty if not needed).
+
 ** FAQ
 
 A cuckoo relies on other birds to hatch its eggs. In a similar manner, this package uses some Elfeed-code and rg to create the search, hence the name.  


### PR DESCRIPTION
This adds a saved-searches feature to cuckoo-search. The feature allows to store Elfeed and/or cuckoo-search strings for later use.